### PR TITLE
explicitly disable libxmlsec1 dynamic loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,15 @@
 
 Work in progress build scripts as we decide how much of other people's software
 to use while building the product.
+
+## testing
+
+To test your packages, use the `-g` flag of pkg to install from the generated
+p5p file:
+
+    pfexec pkg install -g ./work/libxmlsec1-1.2.33.p5p library/libxmlsec1
+
+Clean up when done:
+
+    pfexec pkg uninstall library/libxmlsec1
+

--- a/libxmlsec1/build.sh
+++ b/libxmlsec1/build.sh
@@ -26,7 +26,7 @@ mkdir -p "$WORKAROUND"
 
 #
 # The build will try to detect information about the git repository, but finds
-# garbage-compactor.git, because the source archive we use to build Cockroach
+# garbage-compactor.git, because the source archive we use to build xmlsec
 # is not, itself, a git repository.
 #
 cat >"$WORKAROUND/git" <<'EOF'
@@ -37,7 +37,7 @@ chmod 0755 "$WORKAROUND/git"
 
 NAM='libxmlsec1'
 VER='1.2.33'
-URL="http://www.aleksey.com/xmlsec/download/xmlsec1-$VER.tar.gz"
+URL="https://www.aleksey.com/xmlsec/download/xmlsec1-$VER.tar.gz"
 
 if [[ -x /usr/gcc/10/bin/gcc ]]; then
 	GCC_DIR=/usr/gcc/10/bin
@@ -80,7 +80,9 @@ CFLAGS='-m32' \
     ./configure \
     --prefix=/usr \
     --libdir=/usr/lib \
-    --enable-static=no
+    --enable-static=no \
+    --disable-crypto-dl \
+    --disable-apps-crypto-dl
 
 info "make..."
 gmake -j8
@@ -96,7 +98,9 @@ LDFLAGS='-R/usr/lib/amd64' \
     ./configure \
     --prefix=/usr \
     --libdir=/usr/lib/amd64 \
-    --enable-static=no
+    --enable-static=no \
+    --disable-crypto-dl \
+    --disable-apps-crypto-dl
 
 info "make..."
 gmake -j8


### PR DESCRIPTION
without this, the samael crate will not build due to cannot find
function errors like this:

    error[E0425]: cannot find function `xmlSecOpenSSLShutdown` in module `bindings`
         --> src/xmlsec/xmlsec.rs:98:24
          |
    98    |     unsafe { bindings::xmlSecOpenSSLShutdown() };
          |                        ^^^^^^^^^^^^^^^^^^^^^ help: a function with a similar name exists: `xmlSecCryptoDLShutdown`
          |
         ::: /home/james/samael/target/debug/build/samael-43f9c90eb34cdf2d/out/bindings.rs:23953:5
          |
    23953 |     pub fn xmlSecCryptoDLShutdown() -> ::std::os::raw::c_int;
          |     --------------------------------------------------------- similarly named function `xmlSecCryptoDLShutdown` defined here

The xmlsec code supports dynamic loading and provides indirection with
defines and function pointers:

    src/openssl/crypto.c
    66:    gXmlSecOpenSSLFunctions->cryptoShutdown             = xmlSecOpenSSLShutdown;
    352: * xmlSecOpenSSLShutdown:
    359:xmlSecOpenSSLShutdown(void) {

    include/xmlsec/openssl/symbols.h
    28:#define xmlSecCryptoShutdown                    xmlSecOpenSSLShutdown

    include/xmlsec/openssl/crypto.h
    49:XMLSEC_CRYPTO_EXPORT int                xmlSecOpenSSLShutdown           (void);

Turn all this off, the samael crate references the openssl functions
directly.

Also, put a short blob in the README about testing.