### PR TITLE
Update ClickHouse to 23.5.3.24

### DIFF
--- a/clickhouse/build.sh
+++ b/clickhouse/build.sh
@@ -30,7 +30,7 @@ done
 NAM='clickhouse'
 VER="23.5.3.24"
 URL="https://github.com/ClickHouse/ClickHouse/archive/refs/tags/v$VER-stable.tar.gz"
-SHA256='8a87a72facaa4e01bba01f80c7c879151f38240cf8e7c83372de69bb21d769a4'
+SHA256='be205c2117a35591c20e58aa9cbe0b546258ef005b2825372f5046454c6ca3df'
 
 #
 # Download ClickHouse sources


### PR DESCRIPTION
This PR (hopefully?) is enough to update the clickhouse binaries to 23.5.3.24. 

There is a small change to the URL since the `ClickHouse_sources_with_submodules.tar.gz` file doesn't exist anymore, and the way artefacts are shipped has changed quite a bit (see [23.5.3.24](https://github.com/ClickHouse/ClickHouse/releases/tag/v23.5.3.24-stable) vs [21.10.4.26](https://github.com/ClickHouse/ClickHouse/releases/tag/v21.10.4.26-stable)). I checked the contents of `ClickHouse_sources_with_submodules.tar.gz` and `v21.10.4.26-stable.tar.gz` and they seem identical, so I'm hoping this will work (:crossed_fingers: ).

This PR is related to https://github.com/oxidecomputer/omicron/issues/2158 

@jclulow I'm assuming this runs on buildomat? I'm a bit lost as to where I'm supposed to actually build the artifacts


