### PR TITLE
dice-util: replace dice-cert-check with verifier-cli

### DIFF
--- a/dice-util/build.sh
+++ b/dice-util/build.sh
@@ -74,7 +74,7 @@ cargo build --release --locked
 header "installing $NAM"
 rm -rf "$PROTO"
 mkdir -p "$PROTO/usr/bin"
-for cmd in dice-cert-check dice-cert-tmpl dice-mfg; do
+for cmd in dice-mfg verifier-cli; do
 	cp "target/release/$cmd" "$PROTO/usr/bin/$cmd"
 done
 


### PR DESCRIPTION
`dice-cert-check` was replaced by `verifier-cli`