### PR TITLE
mfg: create mfg package

### DIFF
--- a/mfg/build.sh
+++ b/mfg/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright 2026 Oxide Computer Company
+#
+
+set -o errexit
+set -o pipefail
+
+ROOT=$(cd "$(dirname "$0")" && pwd)
+. "$ROOT/../lib/common.sh"
+
+NAM='mfg'
+CREV=0
+VER="1.0.$CREV"
+
+WORK="$ROOT/work"
+mkdir -p "$WORK"
+PROTO="$WORK/proto"
+rm -rf "$PROTO"
+mkdir -p "$PROTO"
+
+if [[ -z "$OUTPUT_TYPE" ]]; then
+	OUTPUT_TYPE=ips
+fi
+
+case "$OUTPUT_TYPE" in
+ips)
+	make_package_simple "oxide/$NAM" \
+	    'Manufacturing software meta-package' \
+	    "$WORK/proto" \
+	    "$ROOT/mfg.p5m" \
+	    "$VER"
+	header 'build output:'
+	pkgrepo -s "$WORK/repo" list
+	pkgrecv -a -d "$WORK/$NAM-$VER.p5p" -s "$WORK/repo" "oxide/$NAM@$VER"
+	ls -lh "$WORK/$NAM-$VER.p5p"
+	exit 0
+	;;
+none)
+	#
+	# Just leave the build tree as-is without doing any more work.
+	#
+	exit 0
+	;;
+*)
+	fatal "unknown output type: $OUTPUT_TYPE"
+	;;
+esac

--- a/mfg/build.sh
+++ b/mfg/build.sh
@@ -25,6 +25,8 @@ fi
 
 case "$OUTPUT_TYPE" in
 ips)
+	pkgrepo create "$WORK/repo"
+	pkgrepo add-publisher -s "$WORK/repo" helios-dev
 	make_package_simple "oxide/$NAM" \
 	    'Manufacturing software meta-package' \
 	    "$WORK/proto" \

--- a/mfg/build.sh
+++ b/mfg/build.sh
@@ -2,6 +2,15 @@
 #
 # Copyright 2026 Oxide Computer Company
 #
+# `mfg` is a package for the manufacturing software deployed to station
+# computers.  It uses require dependencies to ensure the required tools are
+# installed, and incorporate
+# dependencies to lock against particular versions of those tools.  To date,
+# manufacturing station tools have been managed via a combination of
+# confomat-oxide and ad-hoc pkg installs, leading to version drift between
+# stations.  This package ensures the correct versions are installed and
+# updated in lock step.
+#
 
 set -o errexit
 set -o pipefail
@@ -11,7 +20,7 @@ ROOT=$(cd "$(dirname "$0")" && pwd)
 
 NAM='mfg'
 CREV=0
-VER="1.0.$CREV"
+VER="0.1.$CREV"
 
 WORK="$ROOT/work"
 mkdir -p "$WORK"
@@ -28,7 +37,7 @@ ips)
 	pkgrepo create "$WORK/repo"
 	pkgrepo add-publisher -s "$WORK/repo" helios-dev
 	make_package_simple "oxide/$NAM" \
-	    'Manufacturing software meta-package' \
+	    'Manufacturing software package' \
 	    "$WORK/proto" \
 	    "$ROOT/mfg.p5m" \
 	    "$VER"

--- a/mfg/build.sh
+++ b/mfg/build.sh
@@ -3,13 +3,14 @@
 # Copyright 2026 Oxide Computer Company
 #
 # `mfg` is a package for the manufacturing software deployed to station
-# computers.  It uses require dependencies to ensure the required tools are
-# installed, and incorporate
-# dependencies to lock against particular versions of those tools.  To date,
-# manufacturing station tools have been managed via a combination of
-# confomat-oxide and ad-hoc pkg installs, leading to version drift between
-# stations.  This package ensures the correct versions are installed and
-# updated in lock step.
+# computers.  It uses "require" dependencies to ensure the required tools are
+# installed, and "incorporate" dependencies to lock against particular versions
+# of those tools.
+#
+# To date, manufacturing station tools have been managed via an
+# initial `confomat-oxide` setup followed by ad-hoc pkg installs, leading to
+# version drift between stations.  This package ensures the correct, pinned
+# versions are installed and updated in lock step.
 #
 
 set -o errexit

--- a/mfg/mfg.p5m
+++ b/mfg/mfg.p5m
@@ -39,3 +39,9 @@ depend type=incorporate fmri=pkg:/library/libftdi1@1.5-2.0
 
 depend type=require     fmri=pkg:/library/libusb
 depend type=incorporate fmri=pkg:/library/libusb@1.0.25-2.1
+
+depend type=require     fmri=pkg:/security/oxtpm
+depend type=incorporate fmri=pkg:/security/oxtpm@1.0.9
+
+depend type=require     fmri=pkg:/network/ovpnms
+depend type=incorporate fmri=pkg:/network/ovpnms@1.0.12

--- a/mfg/mfg.p5m
+++ b/mfg/mfg.p5m
@@ -1,0 +1,29 @@
+depend type=require     fmri=pkg:/developer/debug/dice-util
+depend type=incorporate fmri=pkg:/developer/debug/dice-util@0.3.0.475-2.0
+
+depend type=require     fmri=pkg:/developer/debug/embootleby
+depend type=incorporate fmri=pkg:/developer/debug/embootleby@1.0.2.38-2.0
+
+depend type=require     fmri=pkg:/network/faux-mgs
+depend type=incorporate fmri=pkg:/network/faux-mgs@0.1.1.474-2.0
+
+depend type=require     fmri=pkg:/developer/debug/humility
+depend type=incorporate fmri=pkg:/developer/debug/humility@0.12.16.619-2.0
+
+depend type=require     fmri=pkg:/developer/iceprog
+depend type=incorporate fmri=pkg:/developer/iceprog@0.0.809-2.0
+
+depend type=require     fmri=pkg:/diagnostic/lmar
+depend type=incorporate fmri=pkg:/diagnostic/lmar@0.3.4.59-2.1
+
+depend type=require     fmri=pkg:/developer/debug/permission-slip-client
+depend type=incorporate fmri=pkg:/developer/debug/permission-slip-client@1.1.0.610-2.0
+
+depend type=require     fmri=pkg:/network/pilot
+depend type=incorporate fmri=pkg:/network/pilot@0.1.232
+
+depend type=require     fmri=pkg:/network/thundermuffin
+depend type=incorporate fmri=pkg:/network/thundermuffin@0.1.0.12
+
+depend type=require     fmri=pkg:/oxide/platform-identity-cacerts
+depend type=incorporate fmri=pkg:/oxide/platform-identity-cacerts@1.0-2.0

--- a/mfg/mfg.p5m
+++ b/mfg/mfg.p5m
@@ -25,5 +25,11 @@ depend type=incorporate fmri=pkg:/network/pilot@0.1.232
 depend type=require     fmri=pkg:/network/thundermuffin
 depend type=incorporate fmri=pkg:/network/thundermuffin@0.1.0.12
 
+depend type=require     fmri=pkg:/developer/debug/lpc55_support
+depend type=incorporate fmri=pkg:/developer/debug/lpc55_support@0.3.4.151-2.0
+
 depend type=require     fmri=pkg:/oxide/platform-identity-cacerts
 depend type=incorporate fmri=pkg:/oxide/platform-identity-cacerts@1.0-2.0
+
+depend type=require     fmri=pkg:/terminal/picocom
+depend type=incorporate fmri=pkg:/terminal/picocom@3.1.999-2.0

--- a/mfg/mfg.p5m
+++ b/mfg/mfg.p5m
@@ -33,3 +33,9 @@ depend type=incorporate fmri=pkg:/oxide/platform-identity-cacerts@1.0-2.0
 
 depend type=require     fmri=pkg:/terminal/picocom
 depend type=incorporate fmri=pkg:/terminal/picocom@3.1.999-2.0
+
+depend type=require     fmri=pkg:/library/libftdi1
+depend type=incorporate fmri=pkg:/library/libftdi1@1.5-2.0
+
+depend type=require     fmri=pkg:/library/libusb
+depend type=incorporate fmri=pkg:/library/libusb@1.0.25-2.1


### PR DESCRIPTION
Contributes to: https://github.com/oxidecomputer/facade/issues/429 & follows Josh's recommendation.

This PR creates a `mfg` `pkg` to help manage some of the software distributed to manufacturing stations.

I started describing some of as-is manufacturing software distribution here: https://github.com/oxidecomputer/facade/blob/0e1004c49f39e27a13f74b5f2f75124bd1e6a09f/docs/distribution.adoc

