### PR TITLE
mfg: use thundermuffin@0.1.0.9

### DIFF
--- a/mfg/build.sh
+++ b/mfg/build.sh
@@ -20,7 +20,7 @@ ROOT=$(cd "$(dirname "$0")" && pwd)
 . "$ROOT/../lib/common.sh"
 
 NAM='mfg'
-CREV=0
+CREV=1
 VER="0.1.$CREV"
 
 WORK="$ROOT/work"

--- a/mfg/mfg.p5m
+++ b/mfg/mfg.p5m
@@ -23,7 +23,7 @@ depend type=require     fmri=pkg:/network/pilot
 depend type=incorporate fmri=pkg:/network/pilot@0.1.232
 
 depend type=require     fmri=pkg:/network/thundermuffin
-depend type=incorporate fmri=pkg:/network/thundermuffin@0.1.0.12
+depend type=incorporate fmri=pkg:/network/thundermuffin@0.1.0.9
 
 depend type=require     fmri=pkg:/developer/debug/lpc55_support
 depend type=incorporate fmri=pkg:/developer/debug/lpc55_support@0.3.4.151-2.0

--- a/mfg/mfg.p5m
+++ b/mfg/mfg.p5m
@@ -23,7 +23,7 @@ depend type=require     fmri=pkg:/network/pilot
 depend type=incorporate fmri=pkg:/network/pilot@0.1.232
 
 depend type=require     fmri=pkg:/network/thundermuffin
-depend type=incorporate fmri=pkg:/network/thundermuffin@0.1.0.9
+depend type=incorporate fmri=pkg:/network/thundermuffin@0.1.0.10
 
 depend type=require     fmri=pkg:/developer/debug/lpc55_support
 depend type=incorporate fmri=pkg:/developer/debug/lpc55_support@0.3.4.151-2.0


### PR DESCRIPTION
Use `0.1.0.9` thundermuffin in mfg.

Only `argon` was on `0.1.0.12` and `0.1.0.12` is not present in the pkg repository.

I've checked that the other pkgs are ok - 

```
adam@boron ~ $ ./check-mfg-pkgs.sh
OK      developer/debug/dice-util@0.3.0.475-2.0
OK      developer/debug/embootleby@1.0.2.38-2.0
OK      network/faux-mgs@0.1.1.474-2.0
OK      developer/debug/humility@0.12.16.619-2.0
OK      developer/iceprog@0.0.809-2.0
OK      diagnostic/lmar@0.3.4.59-2.1
OK      developer/debug/permission-slip-client@1.1.0.610-2.0
OK      network/pilot@0.1.232
OK      network/thundermuffin@0.1.0.9
OK      developer/debug/lpc55_support@0.3.4.151-2.0
OK      oxide/platform-identity-cacerts@1.0-2.0
OK      terminal/picocom@3.1.999-2.0
OK      library/libftdi1@1.5-2.0
OK      library/libusb@1.0.25-2.1
OK      security/oxtpm@1.0.9
OK      network/ovpnms@1.0.12

16 ok, 0 missing
```