### PR TITLE
mfg: pin packages to versions for helios 3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# alert mfg sw team if mfg packages change
+/mfg/ @adamlouis @chris-wiet @Lydia-Sylla

--- a/mfg/pkglist
+++ b/mfg/pkglist
@@ -2,19 +2,19 @@
 #  <pkg> [version]
 # If the optional version is not provided, the latest published package version
 # is used.
-pkg:/developer/debug/dice-util
-pkg:/developer/debug/embootleby
-pkg:/network/faux-mgs
-pkg:/developer/debug/humility
-pkg:/developer/iceprog
-pkg:/diagnostic/lmar
-pkg:/developer/debug/permission-slip-client
-pkg:/network/pilot
-pkg:/network/thundermuffin
-pkg:/developer/debug/lpc55_support
-pkg:/oxide/platform-identity-cacerts
-pkg:/terminal/picocom
-pkg:/library/libftdi1
-pkg:/library/libusb
-pkg:/security/oxtpm
-pkg:/network/ovpnms
+pkg:/developer/debug/dice-util 0.3.0.481-2.0
+pkg:/developer/debug/embootleby 1.0.2.38-2.0
+pkg:/network/faux-mgs 0.1.1.474-2.0
+pkg:/developer/debug/humility 0.12.16.619-2.0
+pkg:/developer/iceprog 0.0.809-2.0
+pkg:/diagnostic/lmar 0.3.4.59-2.1
+pkg:/developer/debug/permission-slip-client 1.1.0.632-2.0
+pkg:/network/pilot 0.1.232
+pkg:/network/thundermuffin 0.1.0.10
+pkg:/developer/debug/lpc55_support 0.3.4.151-2.0
+pkg:/oxide/platform-identity-cacerts 1.0-2.0
+pkg:/terminal/picocom 3.1.999-2.0
+pkg:/library/libftdi1 1.5-2.0
+pkg:/library/libusb 1.0.25-2.1
+pkg:/security/oxtpm 1.0.9
+pkg:/network/ovpnms 1.0.12

--- a/mfg/pkglist
+++ b/mfg/pkglist
@@ -2,19 +2,19 @@
 #  <pkg> [version]
 # If the optional version is not provided, the latest published package version
 # is used.
-pkg:/developer/debug/dice-util 0.3.0.481-2.0
-pkg:/developer/debug/embootleby 1.0.2.38-2.0
-pkg:/network/faux-mgs 0.1.1.474-2.0
-pkg:/developer/debug/humility 0.12.16.619-2.0
-pkg:/developer/iceprog 0.0.809-2.0
-pkg:/diagnostic/lmar 0.3.4.59-2.1
-pkg:/developer/debug/permission-slip-client 1.1.0.632-2.0
+pkg:/developer/debug/dice-util 0.3.0.481
+pkg:/developer/debug/embootleby 1.0.2.38
+pkg:/network/faux-mgs 0.1.1.474
+pkg:/developer/debug/humility 0.12.16.619
+pkg:/developer/iceprog 0.0.809
+pkg:/diagnostic/lmar 0.3.4.59
+pkg:/developer/debug/permission-slip-client 1.1.0.632
 pkg:/network/pilot 0.1.232
 pkg:/network/thundermuffin 0.1.0.10
-pkg:/developer/debug/lpc55_support 0.3.4.151-2.0
-pkg:/oxide/platform-identity-cacerts 1.0-2.0
-pkg:/terminal/picocom 3.1.999-2.0
-pkg:/library/libftdi1 1.5-2.0
-pkg:/library/libusb 1.0.25-2.1
+pkg:/developer/debug/lpc55_support 0.3.4.151
+pkg:/oxide/platform-identity-cacerts 1.0
+pkg:/terminal/picocom 3.1.999
+pkg:/library/libftdi1 1.5
+pkg:/library/libusb 1.0.25
 pkg:/security/oxtpm 1.0.9
 pkg:/network/ovpnms 1.0.12

--- a/mfg/pkglist
+++ b/mfg/pkglist
@@ -4,17 +4,17 @@
 # is used.
 pkg:/developer/debug/dice-util              0.3.0.481
 pkg:/developer/debug/embootleby             1.0.2.38
-pkg:/network/faux-mgs                       0.1.1.474
+pkg:/network/faux-mgs                       0.1.1.477
 pkg:/developer/debug/humility               0.12.16.619
 pkg:/developer/iceprog                      0.0.809
-pkg:/diagnostic/lmar                        0.3.4.59
+pkg:/diagnostic/lmar                        0.3.13.70
 pkg:/developer/debug/permission-slip-client 1.1.0.632
-pkg:/network/pilot                          0.1.232
+pkg:/network/pilot                          0.1.236
 pkg:/network/thundermuffin                  0.1.0.10
-pkg:/developer/debug/lpc55_support          0.3.4.151
+pkg:/developer/debug/lpc55_support          0.3.5.160
 pkg:/oxide/platform-identity-cacerts        1.0
 pkg:/ooce/terminal/picocom                  3.1
 pkg:/library/libftdi1                       1.5
 pkg:/ooce/library/libusb-1                  1.0.29
-pkg:/security/oxtpm                         1.0.9
-pkg:/network/ovpnms                         1.0.12
+pkg:/security/oxtpm                         1.0.11
+pkg:/network/ovpnms                         1.0.14

--- a/mfg/pkglist
+++ b/mfg/pkglist
@@ -2,19 +2,19 @@
 #  <pkg> [version]
 # If the optional version is not provided, the latest published package version
 # is used.
-pkg:/developer/debug/dice-util 0.3.0.481
-pkg:/developer/debug/embootleby 1.0.2.38
-pkg:/network/faux-mgs 0.1.1.474
-pkg:/developer/debug/humility 0.12.16.619
-pkg:/developer/iceprog 0.0.809
-pkg:/diagnostic/lmar 0.3.4.59
+pkg:/developer/debug/dice-util              0.3.0.481
+pkg:/developer/debug/embootleby             1.0.2.38
+pkg:/network/faux-mgs                       0.1.1.474
+pkg:/developer/debug/humility               0.12.16.619
+pkg:/developer/iceprog                      0.0.809
+pkg:/diagnostic/lmar                        0.3.4.59
 pkg:/developer/debug/permission-slip-client 1.1.0.632
-pkg:/network/pilot 0.1.232
-pkg:/network/thundermuffin 0.1.0.10
-pkg:/developer/debug/lpc55_support 0.3.4.151
-pkg:/oxide/platform-identity-cacerts 1.0
-pkg:/terminal/picocom 3.1.999
-pkg:/library/libftdi1 1.5
-pkg:/library/libusb 1.0.25
-pkg:/security/oxtpm 1.0.9
-pkg:/network/ovpnms 1.0.12
+pkg:/network/pilot                          0.1.232
+pkg:/network/thundermuffin                  0.1.0.10
+pkg:/developer/debug/lpc55_support          0.3.4.151
+pkg:/oxide/platform-identity-cacerts        1.0
+pkg:/ooce/terminal/picocom                  3.1
+pkg:/library/libftdi1                       1.5
+pkg:/ooce/library/libusb-1                  1.0.29
+pkg:/security/oxtpm                         1.0.9
+pkg:/network/ovpnms                         1.0.12


### PR DESCRIPTION
Resolves https://github.com/oxidecomputer/facade/issues/547

This currently just grabs the previous package versions from pre-helios 3 changes.

Edit: Andy noted that we're clear to keep using previous package versions, but provided the list below of what's currently in helios 3 for mfg:
```
atrium% pkg contents -rt depend mfg
TYPE        FMRI
incorporate pkg:/developer/debug/dice-util@0.3.0.481-3.0
incorporate pkg:/developer/debug/embootleby@1.0.2.38-3.0
incorporate pkg:/network/faux-mgs@0.1.1.477-3.0
incorporate pkg:/developer/debug/humility@0.12.16.619-3.0
incorporate pkg:/developer/iceprog@0.0.809-3.0
incorporate pkg:/diagnostic/lmar@0.3.13.70-3.0
incorporate pkg:/developer/debug/permission-slip-client@1.1.0.632-3.0
incorporate pkg:/network/pilot@0.1.233-3.0
incorporate pkg:/network/thundermuffin@0.1.0.10-3.0
incorporate pkg:/developer/debug/lpc55_support@0.3.5.160-3.0
incorporate pkg:/oxide/platform-identity-cacerts@1.0-3.0
incorporate pkg:/terminal/picocom@3.1.999-3.0
incorporate pkg:/library/libftdi1@1.5-3.0
incorporate pkg:/library/libusb@1.0.25-3.0
incorporate pkg:/security/oxtpm@1.0.10-3.0
incorporate pkg:/network/ovpnms@1.0.13-3.0
```

The previous set of versions was:
```
pkg:/developer/debug/dice-util 0.3.0.481-2.0
pkg:/developer/debug/embootleby 1.0.2.38-2.0
pkg:/network/faux-mgs 0.1.1.474-2.0
pkg:/developer/debug/humility 0.12.16.619-2.0
pkg:/developer/iceprog 0.0.809-2.0
pkg:/diagnostic/lmar 0.3.4.59-2.1
pkg:/developer/debug/permission-slip-client 1.1.0.632-2.0
pkg:/network/pilot 0.1.232
pkg:/network/thundermuffin 0.1.0.10
pkg:/developer/debug/lpc55_support 0.3.4.151-2.0
pkg:/oxide/platform-identity-cacerts 1.0-2.0
pkg:/terminal/picocom 3.1.999-2.0
pkg:/library/libftdi1 1.5-2.0
pkg:/library/libusb 1.0.25-2.1
pkg:/security/oxtpm 1.0.9
pkg:/network/ovpnms 1.0.12
```

So the discrepancies between previous and new are:
* `faux-mgs` 0.1.1.474 -> 0.1.1.477
* `lmar` 0.3.4.59 -> 0.3.13.70
* `pilot` 0.1.232 -> 0.1.233
* `lpc55_support` 0.3.4.151 -> 0.3.5.160
* `oxtpm` 1.0.9 -> 1.0.10
* `ovpnms` 1.0.12 -> 1.0.13